### PR TITLE
Remove unused link that caused warning

### DIFF
--- a/themes/osuosl/layouts/partials/head.html
+++ b/themes/osuosl/layouts/partials/head.html
@@ -5,7 +5,6 @@
 
     {{ $styles := resources.Get "css/style.css" }}
     <link rel="stylesheet" href="{{ $styles.Permalink }}">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script type="text/javascript" src="/js/mobile-menu.js"></script>
     <script type="text/javascript" src="/js/search-modal.js"></script>
 </head>


### PR DESCRIPTION
There are still two warnings, but they come from when Pagefind hooks onto the HTML, which can be safely ignored.
