### PR TITLE
Move Amazon Corretto to the former projects lists

### DIFF
--- a/data/projects/hosted.yml
+++ b/data/projects/hosted.yml
@@ -19,6 +19,7 @@
 - name: Amazon Corretto
   services:
     - powerpc
+  status: former
 - name: Anaconda
   services:
     - aarch64

--- a/data/projects/powerdev.yml
+++ b/data/projects/powerdev.yml
@@ -16,11 +16,6 @@
     aarch64, armv7 and x86_64 and s390x are now well supported, ppc64le is still needing some work and optimizations. As
     I don't have access to a ppc64le machine, it is very hard for me to diagnose issues.
   category: foss
-- name: Amazon Corretto
-  description: >-
-    Corretto is Amazon's OpenJDK distribution. Our mission is to make Shenandoah the best garbage collector it can be,
-    on every platform.
-  category: foss
 - name: Anaconda
   description: >-
     Installation program used by Fedora, RHEL, and others; uses POWER support for Continuous Integration and development
@@ -652,6 +647,12 @@
   status: former
 - name: Alberta Speculation
   description: Investigate multi-threaded speculation of alternative paths of execution in a sequential execution
+  category: foss
+  status: former
+- name: Amazon Corretto
+  description: >-
+    Corretto is Amazon's OpenJDK distribution. Our mission is to make Shenandoah the best garbage collector it can be,
+    on every platform.
   category: foss
   status: former
 - name: BearSSL


### PR DESCRIPTION
Amazon Corretto no longer needs their instance, so they've been moved to the former (graduated) project lists.

- `data/projects/hosted.yml`: added `status: former` in place, so the entry moves from "Hosted projects" to "Previously hosted projects" on /projects/ (and the homepage current-project count decrements automatically).
- `data/projects/powerdev.yml`: moved the entry into the file's grouped former block with `status: former`, so it moves from POWER "Current projects" to "Former FOSS Projects".

The historical blog post that mentions Corretto was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)