### PR TITLE
Fix Hugo deprecation warnings

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://osuosl.org/'
-languageCode = 'en-us'
+locale = 'en-us'
 title = 'OSU Open Source Lab'
 timeZone = 'America/Los_Angeles'
 

--- a/layouts/_shortcodes/people.html
+++ b/layouts/_shortcodes/people.html
@@ -6,7 +6,7 @@
   per-person deep link from the site search.
   */
 -}}
-{{ range site.Data.people }}
+{{ range hugo.Data.people }}
   <section class="person">
     <h2 id="{{ .id }}"><a href="#{{ .id }}">{{ .name }}</a></h2>
     <p class="person-role">{{ .role }}</p>

--- a/layouts/_shortcodes/project_table.html
+++ b/layouts/_shortcodes/project_table.html
@@ -9,7 +9,7 @@ are current category= filter on the entries' category key (omit to include all) 
 appended Rows sort by name. The second column renders the entries' services list when present (the hosted list),
 otherwise their description. */ -}}
 {{- $key := .Get "data" -}}
-{{- $data := index site.Data.projects $key -}}
+{{- $data := index hugo.Data.projects $key -}}
 {{- if not $data -}}
   {{- errorf "project_table: no data/projects/%s.yml (page %s)" $key .Position -}}
 {{- end -}}

--- a/layouts/_shortcodes/request-form.html
+++ b/layouts/_shortcodes/request-form.html
@@ -7,7 +7,7 @@
 The data file carries the per-form pieces (send_to, subject_prefix, contact, fields); shared formsender settings live in
 [params.formsender]. Field markup comes from the form-field partial. */ -}}
 {{- $name := .Get 0 -}}
-{{- $form := index site.Data.forms $name -}}
+{{- $form := index hugo.Data.forms $name -}}
 {{- if not $form -}}
   {{- errorf "request-form: no data/forms/%s.yml (page %s)" $name .Position -}}
 {{- end -}}

--- a/layouts/_shortcodes/sponsors.html
+++ b/layouts/_shortcodes/sponsors.html
@@ -3,7 +3,7 @@
   same file): linked logo plus the entry's blurb.
   */
 -}}
-{{ range site.Data.sponsors }}
+{{ range hugo.Data.sponsors }}
   <section class="sponsor">
     <a href="{{ .url }}">
       {{- partial "responsive-image.html" (dict "src" .logo "alt" (printf "%s logo" .name) "class" "img-sponsors") -}}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -40,9 +40,9 @@
       {{ $founded := time.AsTime site.Params.founded }}
       {{ $years := sub now.Year $founded.Year }}
       {{ if lt (now.Format "01-02") ($founded.Format "01-02") }}{{ $years = sub $years 1 }}{{ end }}
-      {{ $currentProjects := sub (len site.Data.projects.hosted) (len (where site.Data.projects.hosted "status" "former")) }}
+      {{ $currentProjects := sub (len hugo.Data.projects.hosted) (len (where hugo.Data.projects.hosted "status" "former")) }}
       <div class="row g-4 text-center">
-        {{ range site.Data.stats }}
+        {{ range hugo.Data.stats }}
           {{ $number := .number }}
           {{ if eq .compute "years" }}
             {{ $number = $years }}
@@ -63,7 +63,7 @@
       <h2>Hosting for open source projects</h2>
       <p>Based on your needs, we offer unmanaged and managed hosting across several environments:</p>
       <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4">
-        {{ range site.Data.services }}
+        {{ range hugo.Data.services }}
           <div class="col">
             <div class="card service-card">
               <div class="card-body">
@@ -91,12 +91,12 @@
     <div class="container-site">
       <h2>Trusted by open source communities</h2>
       <div class="featured-projects">
-        {{ range site.Data.featured_projects }}
+        {{ range hugo.Data.featured_projects }}
           <a class="featured-project" href="{{ .url }}">{{ .name }}</a>
         {{ end }}
       </div>
       <p class="mt-3 mb-0">
-        {{ $currentProjects := sub (len site.Data.projects.hosted) (len (where site.Data.projects.hosted "status" "former")) }}
+        {{ $currentProjects := sub (len hugo.Data.projects.hosted) (len (where hugo.Data.projects.hosted "status" "former")) }}
         <a href="{{ "projects/" | relURL }}">See all {{ $currentProjects }} hosted projects &rarr;</a>
       </p>
     </div>
@@ -122,7 +122,7 @@
     <div class="container-site">
       <h2>Supported by</h2>
       <div class="sponsor-row">
-        {{ range site.Data.sponsors }}
+        {{ range hugo.Data.sponsors }}
           <a href="{{ .url }}">
             <img src="{{ .logo | relURL }}" alt="{{ .name }}" height="56" />
           </a>


### PR DESCRIPTION
Hugo 0.165 on web2 emits two deprecation warnings on every build:

```
WARN deprecated: project config key languageCode was deprecated in Hugo v0.158.0 ... Use locale instead.
WARN deprecated: .Site.Data was deprecated in Hugo v0.156.0 ... Use hugo.Data instead.
```

- `config/_default/hugo.toml`: `languageCode` → `locale`.
- Nine `site.Data` lookups in `layouts/home.html` and the shortcodes → `hugo.Data`. The `$site.Data.Integrity` in `layouts/baseof.html` is a *resource's* `.Data` (fingerprint SRI hash), not site data, so it is unchanged.

## Verification

Built both before and after with `hugo_extended_0.165.0` (matching web2):

- Before: 2 warnings. After: no warnings.
- `diff -rq` of the full `public/` tree before vs. after: **no differences** — the rendered site is byte-identical, including `<language>en-us</language>` in the RSS feeds.

## Note

This raises the minimum Hugo version to **v0.158.0** (`hugo.Data` needs ≥0.156, `locale` needs ≥0.158). web2 is on v0.165.0 so CI is fine, but anyone still on an older local Hugo will need to upgrade — an older binary fails with `can't evaluate field Data in type interface {}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)